### PR TITLE
Replace -H/--history with negative --days for history

### DIFF
--- a/src/bettingbook.py
+++ b/src/bettingbook.py
@@ -34,11 +34,11 @@ def bettable_balance(balance):
     return False if float(balance) <= 0.00 else True
 
 
-def check_options(history, bet, live, today, refresh, matches):
-    if history and live or history and today:
+def check_options(days, bet, live, today, refresh, matches):
+    if days < 0 and (live or today):
         raise IncorrectParametersException(
-            "--history and --days is not supported for --live/--today. "
-            "Use --matches to use these parameters"
+            "Negative --days is not supported for --live/--today. "
+            "Use --matches to view history."
         )
     if bet and live:
         raise IncorrectParametersException(
@@ -56,15 +56,15 @@ def check_options(history, bet, live, today, refresh, matches):
         )
 
 
-def check_options_standings(leagues, history):
+def check_options_standings(leagues, days):
     if not leagues:
         raise IncorrectParametersException(
             "Please specify a league. " "Example --standings --league=EN1"
         )
-    if history:
+    if days < 0:
         raise IncorrectParametersException(
-            "--history and --days is not supported for --standings. "
-            "Use --matches to use these parameters"
+            "Negative --days is not supported for --standings. "
+            "Use --matches to view history."
         )
     for league in leagues:
         if league.endswith("C") and league not in ["WC", "EC"]:
@@ -145,19 +145,13 @@ def get_possible_leagues():
     "--days",
     "-d",
     default=7,
+    type=int,
     show_default=True,
     help=(
-        "The number of days in the future for which you "
-        "want to see the scores, or the number of days "
-        "in the past when used with --history"
+        "Number of days ahead to show (e.g. -d 7), "
+        "or negative for history (e.g. -d -7 for past 7 days). "
+        "Use with --matches (-M)."
     ),
-)
-@click.option(
-    "--history",
-    "-H",
-    is_flag=True,
-    default=False,
-    help="Displays past games. Use with --matches (-M).",
 )
 @click.option(
     "--details",
@@ -214,7 +208,6 @@ def main(
     league,
     sort_by,
     days,
-    history,
     details,
     odds,
     not_started,
@@ -240,7 +233,7 @@ def main(
         Parameters = namedtuple(
             "parameters",
             "url, msg, league_name, sort_by, days, "
-            "show_history, show_details, show_odds, not_started, refresh, place_bet, date_format, type_sort",
+            "show_details, show_odds, not_started, refresh, place_bet, date_format, type_sort",
         )
 
         def get_multi_matches(filename, parameters):
@@ -261,7 +254,6 @@ def main(
                 ],
                 None,
                 sort_by,
-                None,
                 None,
                 details,
                 True,
@@ -288,14 +280,8 @@ def main(
             get_multi_matches(filename, parameters)
             return
 
-        if history and not (live or today or matches):
-            click.secho(
-                "--history has no effect on its own. Use it with --matches (-M).",
-                fg="red",
-                bold=True,
-            )
-        elif live or today or matches:
-            check_options(history, bet, live, today, refresh, matches)
+        if live or today or matches:
+            check_options(days, bet, live, today, refresh, matches)
             date_format = convert.format_date(ch.get("profile", "date_format"))
             if sort_by is None:
                 sort_by = "league"
@@ -313,7 +299,6 @@ def main(
                     league,
                     sort_by,
                     days,
-                    history,
                     details,
                     odds,
                     not_started,
@@ -332,7 +317,6 @@ def main(
                     league,
                     sort_by,
                     days,
-                    history,
                     details,
                     odds,
                     not_started,
@@ -344,14 +328,10 @@ def main(
             else:
                 parameters = Parameters(
                     "fixtures/between/",
-                    [
-                        [f"No matches in the past {str(days)} days."],
-                        [f"No matches in the coming {str(days)} days."],
-                    ],
+                    None,
                     league,
                     sort_by,
                     days,
-                    history,
                     details,
                     odds,
                     not_started,
@@ -364,7 +344,7 @@ def main(
             return
 
         if standings:
-            check_options_standings(league, history)
+            check_options_standings(league, days)
             rh.get_standings(league, details)
             return
 

--- a/src/request_handler.py
+++ b/src/request_handler.py
@@ -134,11 +134,11 @@ class RequestHandler(object):
             self.params.pop("markets", None)
 
     @staticmethod
-    def set_start_end(show_history, days):
+    def set_start_end(days):
         now = datetime.datetime.now()
-        if show_history:
+        if days < 0:
             start = datetime.datetime.strftime(
-                now - datetime.timedelta(days=days), "%Y-%m-%d"
+                now + datetime.timedelta(days=days), "%Y-%m-%d"
             )
             end = datetime.datetime.strftime(
                 now - datetime.timedelta(days=1), "%Y-%m-%d"
@@ -178,7 +178,7 @@ class RequestHandler(object):
             self.try_to_get_match_data(parameters, i == 0)
 
     def try_to_get_match_data(self, parameters, first=False):
-        start, end = self.set_start_end(parameters.show_history, parameters.days)
+        start, end = self.set_start_end(parameters.days)
         try:
             self.get_match_data(parameters, start, end, first)
         except APIErrorException as e:
@@ -207,10 +207,18 @@ class RequestHandler(object):
         # no fixtures in the timespan. display a help message and return
         if len(fixtures_results) == 0:
             if parameters.type_sort == "matches":
-                if parameters.show_history:
-                    click.secho("".join(parameters.msg[0]), fg="red", bold=True)
+                if parameters.days < 0:
+                    click.secho(
+                        f"No matches in the past {abs(parameters.days)} days.",
+                        fg="red",
+                        bold=True,
+                    )
                 else:
-                    click.secho("".join(parameters.msg[1]), fg="red", bold=True)
+                    click.secho(
+                        f"No matches in the coming {parameters.days} days.",
+                        fg="red",
+                        bold=True,
+                    )
             else:
                 click.secho(parameters.msg[0], fg="red", bold=True)
             return


### PR DESCRIPTION
## Summary
- Removes the `-H`/`--history` flag entirely
- Use negative `--days` instead: `-d -7` shows the past 7 days, `-d 7` shows the next 7 days
- `set_start_end` now detects history via `days < 0`
- "No matches" error message is now built inline from `abs(days)` rather than stored in the Parameters msg list

## Usage
```
# Before
bettingbook -M -H -d 7

# After
bettingbook -M -d -7
```

## Test plan
- [ ] `bettingbook -M -d -7` shows past 7 days of matches
- [ ] `bettingbook -M -d 7` shows upcoming 7 days
- [ ] `bettingbook -M -d -1` shows yesterday's matches
- [ ] `bettingbook -L -d -1` shows error about negative days not supported for --live
- [ ] `bettingbook --help` shows updated --days description

🤖 Generated with [Claude Code](https://claude.com/claude-code)