### PR TITLE
Fix double API call in get_multi_matches

### DIFF
--- a/src/request_handler.py
+++ b/src/request_handler.py
@@ -202,9 +202,7 @@ class RequestHandler(object):
         if len(fixtures) == 0:
             click.secho(parameters.msg[0], fg="red", bold=True)
             return
-        self.writer.league_scores(
-            self._get(f"fixtures/multi/{match_ids}"), parameters, True, predictions
-        )
+        self.writer.league_scores(fixtures, parameters, True, predictions)
 
     def get_match_data(self, parameters, start, end, first=False):
         if parameters.type_sort == "matches":

--- a/src/writers.py
+++ b/src/writers.py
@@ -100,7 +100,11 @@ Your timezone: {profile_data['timezone']}""",
         stages = {}
         for entry in sorted(
             standings_data,
-            key=lambda x: (x.get("stage_id", 0), x.get("group_id") or 0, x.get("position", 0)),
+            key=lambda x: (
+                x.get("stage_id", 0),
+                x.get("group_id") or 0,
+                x.get("position", 0),
+            ),
         ):
             stages.setdefault(entry.get("stage_id", 0), []).append(entry)
         for stage_teams in stages.values():
@@ -115,7 +119,9 @@ Your timezone: {profile_data['timezone']}""",
                 for group_teams in groups.values():
                     if not group_teams:
                         continue
-                    group_name = (group_teams[0].get("group") or {}).get("name") or stage_name
+                    group_name = (group_teams[0].get("group") or {}).get(
+                        "name"
+                    ) or stage_name
                     self.standings_header(league_name, show_details, group_name)
                     self._print_standings_table(group_teams, show_details)
             else:


### PR DESCRIPTION
## Summary
`get_multi_matches` was calling `fixtures/multi/{match_ids}` twice — once to check if the result was empty, then again to pass to `league_scores`. The second call is wasted; reuse the result from the first.

## Test plan
- [ ] Open bets with `-OB -D` still displays correctly
- [ ] Only one request made to `fixtures/multi/...` per invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)