### PR TITLE
Fix bet match validation and pagination params leak

### DIFF
--- a/src/request_handler.py
+++ b/src/request_handler.py
@@ -110,6 +110,7 @@ class RequestHandler(object):
                 next_data = next_parts.get("data")
                 if next_data:
                     data.extend(next_data)
+            self.params.pop("page", None)
         return data
 
     def get_league_ids(self):
@@ -285,7 +286,7 @@ class RequestHandler(object):
         matches = set()
         for match_id in match_bet:
             try:
-                if 0 <= int(match_id) > max_match_id:
+                if int(match_id) < 1 or int(match_id) > max_match_id:
                     click.secho(
                         f"The match with id {match_id} is an invalid match.",
                         fg="red",

--- a/src/writers.py
+++ b/src/writers.py
@@ -100,7 +100,11 @@ Your timezone: {profile_data['timezone']}""",
         stages = {}
         for entry in sorted(
             standings_data,
-            key=lambda x: (x.get("stage_id", 0), x.get("group_id") or 0, x.get("position", 0)),
+            key=lambda x: (
+                x.get("stage_id", 0),
+                x.get("group_id") or 0,
+                x.get("position", 0),
+            ),
         ):
             stages.setdefault(entry.get("stage_id", 0), []).append(entry)
         for stage_teams in stages.values():
@@ -115,7 +119,9 @@ Your timezone: {profile_data['timezone']}""",
                 for group_teams in groups.values():
                     if not group_teams:
                         continue
-                    group_name = (group_teams[0].get("group") or {}).get("name") or stage_name
+                    group_name = (group_teams[0].get("group") or {}).get(
+                        "name"
+                    ) or stage_name
                     self.standings_header(league_name, show_details, group_name)
                     self._print_standings_table(group_teams, show_details)
             else:


### PR DESCRIPTION
## Summary
Two bugs in `request_handler.py`:

**1. `check_match_bet` invalid condition**
`0 <= int(match_id) > max_match_id` uses Python's chained comparison, which means `0 <= x AND x > max`. This silently accepts `match_id=0` (not a valid match number). Fixed to `x < 1 or x > max_match_id`.

**2. Pagination `page` param leak**
After fetching multiple pages, `self.params["page"]` was left set to the last page number. Any subsequent API call on the same `RequestHandler` instance would include `page=N` unintentionally. Fixed by popping the key after pagination completes.

## Test plan
- [ ] Entering `0` when prompted for a match to bet on shows "invalid match" error
- [ ] Leagues with multiple API pages (e.g. `/leagues`) still load all data correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)