### PR TITLE
Fall back gracefully when odds not in Sportmonks plan

### DIFF
--- a/src/request_handler.py
+++ b/src/request_handler.py
@@ -182,7 +182,20 @@ class RequestHandler(object):
         try:
             self.get_match_data(parameters, start, end, first)
         except APIErrorException as e:
-            click.secho(str(e), fg="red", bold=True)
+            if parameters.show_odds and "not accessible from your plan" in str(e):
+                click.secho(
+                    "Odds not available on your plan, showing matches without odds.",
+                    fg="yellow",
+                    bold=True,
+                )
+                self.params["include"] = self.params["include"].replace(";odds", "")
+                self.params.pop("markets", None)
+                try:
+                    self.get_match_data(parameters, start, end, first)
+                except APIErrorException as e2:
+                    click.secho(str(e2), fg="red", bold=True)
+            else:
+                click.secho(str(e), fg="red", bold=True)
 
     def get_multi_matches(self, match_ids, predictions, parameters):
         """


### PR DESCRIPTION
## Summary

- When `-O` (odds) is passed and the Sportmonks API returns 403 ("not accessible from your plan"), instead of stopping with an error the request is retried without odds
- Shows a yellow warning: _"Odds not available on your plan, showing matches without odds."_
- Any other 403 (e.g. bad API key or wrong endpoint) still shows the red error as before

## Test plan

- [ ] Run `bettingbook -MOD` on a plan without odds — should show a yellow warning then display matches normally
- [ ] Run `bettingbook -MOD` on a plan with odds — should show matches with odds as before
- [ ] Run `bettingbook -MD` (no odds flag) — should be unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)